### PR TITLE
Wagtail 2.2+ support. Remove unrelated features control. Update ignor…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 *pyc
 dist
 *.egg-info/
+deploy_local
+/.venv3

--- a/draftail_katex/wagtail_hooks.py
+++ b/draftail_katex/wagtail_hooks.py
@@ -1,86 +1,10 @@
 from .katex import KaTeXEntityElementHandler, katex_entity_decorator
 from django.conf import settings
 from django.utils.html import format_html
-from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.rich_text.editors.draftail import features as draftail_features
-from wagtail.admin.rich_text.editors.draftail.features import InlineStyleFeature
 from wagtail.core import hooks
 
-
-'''
-This is used to set up the default features.
-'''
-@hooks.register('register_rich_text_features')
-def register_default_features(features):
-    """
-    Set up the default features we want to allow in Wagtail RichTextFields.
-    """
-    features.default_features = ['bold', 'italic', 'link', 'ol', 'ul', 'document-link']
-
-
-'''
-This is used to register additional rich text features.
-'''
-@hooks.register('register_rich_text_features')
-def register_additional_draftail_features(features):
-    """
-    Registering the `monospace`, `subscript`, and `superscript` features, using Draft.js inline style
-    types, and is stored as HTML appropriate tags.
-    """
-    feature_to_add = []
-
-    feature_to_add.append({
-        'feature_name': 'monospace',
-        'draftail_type': 'CODE',
-        'html_tag': 'code',
-        'label': '{ }',
-        'description': 'Monospace'})
-    feature_to_add.append({
-        'feature_name': 'superscript',
-        'draftail_type': 'SUPERSCRIPT',
-        'html_tag': 'sup',
-        'icon': 'icon icon-fa-superscript',
-        'description': 'Superscript'})
-    feature_to_add.append({
-        'feature_name': 'subscript',
-        'draftail_type': 'SUBSCRIPT',
-        'html_tag': 'sub',
-        'icon': 'icon icon-fa-subscript',
-        'description': 'Subscript'})
-
-    feature_to_add.append({
-        'feature_name': 'strikethrough',
-        'draftail_type': 'STRIKETHROUGH',
-        'html_tag': 's',
-        'label': 'S',
-        'description': 'Strikethrough'})
-
-    for feature in feature_to_add:
-        # Configure how Draftail handles the feature in its toolbar.
-        control = {}
-        if 'draftail_type' in feature:
-            control['type'] = feature['draftail_type']
-        if 'label' in feature:
-            control['label'] = feature['label']
-        if 'icon' in feature:
-            control['icon'] = feature['icon']
-        if 'description' in feature:
-            control['description'] = feature['description']
-
-        # Call register_editor_plugin to register the configuration for Draftail.
-        features.register_editor_plugin(
-            'draftail', feature['feature_name'], InlineStyleFeature(control)
-        )
-
-        # Configure the content transform from the DB to the editor and back.
-        db_conversion = {
-            'from_database_format': {feature['html_tag']: InlineStyleElementHandler(feature['draftail_type'])},
-            'to_database_format': {'style_map': {feature['draftail_type']: feature['html_tag']}},
-        }
-
-        # Call register_converter_rule to register the content transformation conversion.
-        features.default_features.append(feature['feature_name'])
-        features.register_converter_rule('contentstate', feature['feature_name'], db_conversion)
 
 
 '''
@@ -102,9 +26,24 @@ def register_rich_text_features(features):
         'description': 'KaTeX',
     }
 
-    features.register_editor_plugin(
-        'draftail', feature_name, draftail_features.EntityFeature(control)
-    )
+    if WAGTAIL_VERSION >= (2, 2):
+        features.register_editor_plugin(
+            'draftail', feature_name, draftail_features.EntityFeature(control,
+                js=[
+                    '{}draftail_katex/js/katex.min.js'.format(settings.STATIC_URL),
+                    '{}draftail_katex/js/wagtail_draftail_katex.js'.format(settings.STATIC_URL),
+                ],
+                css={
+                    'all': [
+                        '{}draftail_katex/css/katex.min.css'.format(settings.STATIC_URL),
+                    ]
+                }
+            )
+        )
+    else:
+        features.register_editor_plugin(
+            'draftail', feature_name, draftail_features.EntityFeature(control)
+        )
 
     features.register_converter_rule('contentstate', feature_name, {
         'from_database_format': {'div[data-katex-text]': KaTeXEntityElementHandler()},
@@ -113,26 +52,28 @@ def register_rich_text_features(features):
     # Below is the insertion of the js file wagtail_draft_katex.js, which handles the React functionality.
 
 
-'''
-This inserts additional JS files on the wagtail editor pages
-'''
-@hooks.register('insert_editor_js')
-def insert_editor_js():
-    assets_files = [
-        '{}draftail_katex/css/katex.min.css'.format(settings.STATIC_URL),
-        '{}wagtailadmin/js/draftail.js'.format(settings.STATIC_URL),
-        '{}draftail_katex/js/wagtail_draftail_katex.js'.format(settings.STATIC_URL),
-        '{}draftail_katex/js/katex.min.js'.format(settings.STATIC_URL),
-    ]
+if WAGTAIL_VERSION < (2, 2):
+    '''
+    Needed only for wagtail < 2.2
+    This inserts additional JS files on the wagtail editor pages
+    '''
+    @hooks.register('insert_editor_js')
+    def insert_editor_js():
+        assets_files = [
+            '{}draftail_katex/css/katex.min.css'.format(settings.STATIC_URL),
+            '{}wagtailadmin/js/draftail.js'.format(settings.STATIC_URL),
+            '{}draftail_katex/js/wagtail_draftail_katex.js'.format(settings.STATIC_URL),
+            '{}draftail_katex/js/katex.min.js'.format(settings.STATIC_URL),
+        ]
 
-    return format_html("""
-    <link rel="stylesheet" href="{css}" >
-    <script src="{katex}"></script>
-    <script src="{draftail}"></script>
-    <script src="{wagtaildraftail}"></script>
-    """.format(css=assets_files[0],
-               draftail=assets_files[1],
-               wagtaildraftail=assets_files[2],
-               katex=assets_files[3],
-               )
-   )
+        return format_html("""
+        <link rel="stylesheet" href="{css}" >
+        <script src="{katex}"></script>
+        <script src="{draftail}"></script>
+        <script src="{wagtaildraftail}"></script>
+        """.format(css=assets_files[0],
+                   draftail=assets_files[1],
+                   wagtaildraftail=assets_files[2],
+                   katex=assets_files[3],
+                   )
+       )

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ with open ("readme.md", "r") as fp:
 from setuptools import setup, find_packages
 
 setup(name='wagtail-draftail-katex',
-      version='0.1.1',
-      description='This will be an integration of a KaTex into the Wagtail CMS Draftail editor.',
+      version='0.1.2',
+      description='Integrate KaTex render into the Wagtail CMS Draftail editor.',
       long_description=long_description,
       long_description_content_type = "text/markdown",
       url='https://github.com/gatensj/wagtail-draftail-katex',


### PR DESCRIPTION
I removed the unrelated “register_rich_text_features” logic since this plugin should only change features related to it’s use, not determine a default set of features for the site using the plugin.

Added some additional items to gitignore

Updated the setup.py description to be more concise and cover the plugin intent.